### PR TITLE
Add major version 4 & define 3-stable release branch

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -45,11 +45,13 @@ github:
 
 release_branches:
   - main:
+      version_constraint: "4.*"
+  - 3-stable:
       version_constraint: "3.*"
   - 2-stable:
       version_constraint: "2.*"
   - 1-stable:
-      version_constraint: "1.*"  
+      version_constraint: "1.*"
 
 subscriptions:
   # These actions are taken, in order they are specified, anytime a Pull Request is merged.


### PR DESCRIPTION
## Description
Changes to prepare for subsequent Chef Infra Client major version release will continue in `main` branch. Patches needed in Chef Infra Client 18.x will be available in `3-stable` branch.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
