### PR TITLE
Modify freebsd builder -freebsd-13

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -95,5 +95,5 @@ builder-to-testers-map:
     - windows-2016-x86_64
     - windows-2019-x86_64
     - windows-2022-x86_64
-    - windows-10-x86_64
+    #- windows-10-x86_64
     - windows-11-x86_64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -51,8 +51,7 @@ builder-to-testers-map:
     - el-9-aarch64
   el-9-x86_64:
     - el-9-x86_64
-  freebsd-12-amd64:
-    - freebsd-12-amd64
+  freebsd-13-amd64:
     - freebsd-13-amd64
   mac_os_x-11-x86_64:
     - mac_os_x-11-x86_64
@@ -96,5 +95,5 @@ builder-to-testers-map:
     - windows-2012r2-x86_64
     - windows-2016-x86_64
     - windows-2022-x86_64
-    - windows-10-x86_64
+    #- windows-10-x86_64
     - windows-11-x86_64

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 8e647fec6cd592628f6914ab96a2b1404543a303
+  revision: 99965d0f928c0af9e218dd5e2251f2cc53f47a20
   branch: main
   specs:
-    omnibus-software (24.2.311)
+    omnibus-software (24.4.318)
       omnibus (>= 9.0.0)
 
 GIT


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This changes will remove freebsd 12 from pipeline and updates freebsd 13 as builder 
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
