### PR TITLE
remove mac 10.15 from release pipeline and add mac 11 as builder

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -54,8 +54,7 @@ builder-to-testers-map:
   freebsd-12-amd64:
     - freebsd-12-amd64
     - freebsd-13-amd64
-  mac_os_x-10.15-x86_64:
-    - mac_os_x-10.15-x86_64
+  mac_os_x-11-x86_64:
     - mac_os_x-11-x86_64
     - mac_os_x-12-x86_64
   mac_os_x-11-arm64:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
this pr will remove mac 10.15 since we are no longer supporting and also making mac 11 as builder

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
