### PR TITLE
Updating Omnibus Software

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 85f02719cceb5a158a48a1ba9d5c0557171e4ac3
+  revision: 51d02fed12257bd713bf013e04da0135c4d0a327
   branch: main
   specs:
-    omnibus-software (24.5.322)
+    omnibus-software (24.6.323)
       ffi (< 1.17.0)
       omnibus (>= 9.0.0)
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This is a crazy PR: So, we have this PR in omnibus-software [here](https://github.com/chef/omnibus-software/pull/1881). That patches resolv.rb to overcome a weird error. The current version of Omnibus-Software in Chef-Foundation does not contain that update. As a result, 1) Various builders/testers that use Chef-18 to build Chef-17 throw an encoding error on the Windows nodes when testing some things and 2) Chef-18 is vulnerable to the same issue although it has not been reported yet.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
