### PR TITLE
use openssl gem 3.2.0 along with chef-foundation 3.1.20 for AIX to get over infra-client error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "pedump"
 
 gem "chefstyle"
 
+gem "openssl", "~> 3.2.0"
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need
 # the Test Kitchen-based build lab. You can skip these unnecessary dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,6 +308,7 @@ GEM
       net-ssh (>= 4.0.0)
     netrc (0.11.0)
     nori (2.6.0)
+    openssl (3.2.0)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -534,6 +535,7 @@ DEPENDENCIES
   omnibus!
   omnibus-software!
   pedump
+  openssl (~> 3.2.0)
   rake
   test-kitchen (>= 1.23)
   winrm-fs (~> 1.0)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Since AIX is failing on infra-client and with 3.1.20 chef-foundation and openssl gem 3.2.0 the build is going fine and the plan here is to build a net new chef-foundation version with the combination of 3.1.20 changes and an openssl gem 3.2.0 to target this only for AIX on infra-client
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
