### PR TITLE
remove el-6 and update digi cert token for windows platforms

### DIFF
--- a/.expeditor/adhoc-canary.omnibus.yml
+++ b/.expeditor/adhoc-canary.omnibus.yml
@@ -25,8 +25,6 @@ builder-to-testers-map:
   debian-10-aarch64:
     - debian-10-aarch64
     - debian-11-aarch64
-  el-6-x86_64:
-    - el-6-x86_64
   el-7-aarch64:
     - el-7-aarch64
     - amazon-2-aarch64

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -28,8 +28,6 @@ builder-to-testers-map:
   debian-10-aarch64:
     - debian-10-aarch64
     - debian-11-aarch64
-  el-6-x86_64:
-    - el-6-x86_64
   el-7-aarch64:
     - el-7-aarch64
     - amazon-2-aarch64

--- a/config/projects/chef-foundation.rb
+++ b/config/projects/chef-foundation.rb
@@ -90,7 +90,7 @@ package :msi do
   upgrade_code msi_upgrade_code
   wix_candle_extension "WixUtilExtension"
   wix_light_extension "WixUtilExtension"
-  signing_identity "769E6AF679126F184850AAC7C5C823A80DB3ADAA", machine_store: false, keypair_alias: "key_495941360"
+  signing_identity "7D16AE73AB249D473362E9332D029089DBBB89B2", machine_store: false, keypair_alias: "key_875762014"
   parameters ProjectLocationDir: project_location_dir
 end
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Recently we updated the digi cert token for windows platforms so picked that here and el-6 is no longer supported hence removing it from release pipeline
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
