### PR TITLE
Fix openssl- 3.2.0 gem issue and Update Mixlib-log gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: b97bb4e3e1319ca1c06b1a06f1f6354d3514ff51
+  revision: 1c244b8dfe1e1c8037353d174f54db0251cc69af
   branch: main
   specs:
     omnibus-software (24.6.323)

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -31,6 +31,7 @@ openssl_version_default =
 override "openssl", version: ENV.fetch("OPENSSL_OVERRIDE", openssl_version_default)
 override "pkg-config-lite", version: "0.28-1"
 override :ruby, version: aix? ? "3.0.3" : ENV.fetch("RUBY_OVERRIDE", "3.1.6"), openssl_gem: "3.2.0"
+override "mixlib-log", version: aix? ? "3.1.1" : "3.2.0"
 override "ruby-windows-devkit-bash", version: "3.1.23-4-msys-1.0.18"
 override "ruby-msys2-devkit", version: ENV.fetch("MSYS_OVERRIDE", "3.1.6-1")
 override "util-macros", version: "1.19.0"


### PR DESCRIPTION
The newer version of mixlib-log we use in Chef-18 (3.2.0) requires Ruby 3.1. For various build/licensing reasons, we are keeping AIX on Ruby 3.0. Therefore we need to update Chef-Foundation overrides to account for that.



<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
