### PR TITLE
Updating default libxslt version in an override

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -9,6 +9,7 @@ override "libiconv", version: "1.16"
 override "liblzma", version: "5.2.5"
 override "libtool", version: "2.4.2"
 override "libarchive", version: "3.6.1"
+override "libxslt", version: "1.1.42"
 
 if solaris?
   # Chef Infra Client failed to install on Solaris V11.4.47 - CHEF-7695


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Here we update the default version of libxslt being used in Chef-18. This is the matching version for a Libxml2 CVE update we pushed into Ominbus-Software a bit ago

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
