### PR TITLE
update nokogiri to overcome CVE and pin libxml2 and libxslt to overri…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,7 @@ GEM
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt_pbkdf (1.1.1)
+    bcrypt_pbkdf (1.1.1-x64-mingw-ucrt)
     berkshelf (8.0.9)
       chef (>= 15.7.32)
       chef-config
@@ -111,6 +112,7 @@ GEM
       chef-powershell (~> 18.1.0)
       chef-utils (= 18.4.12)
       chef-vault
+      chef-win32-api (~> 1.11.0)
       chef-zero (>= 14.0.11)
       corefoundation (~> 0.3.4)
       diff-lcs (>= 1.2.4, < 1.6.0, != 1.4.0)
@@ -165,6 +167,7 @@ GEM
       concurrent-ruby (~> 1.0)
     chef-utils (18.4.12)
       concurrent-ruby
+    chef-win32-api (1.11.0)  
     chef-vault (4.1.11)
     chef-zero (15.0.11)
       ffi-yajl (~> 2.2)
@@ -195,6 +198,7 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.16.3)
+    ffi (1.16.3-x64-mingw-ucrt)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     ffi-win32-extensions (1.0.4)
@@ -278,11 +282,6 @@ GEM
     mixlib-log (3.0.9)
     mixlib-shellout (3.2.7)
       chef-utils
-    mixlib-shellout (3.2.7-universal-mingw32)
-      chef-utils
-      ffi-win32-extensions (~> 1.0.3)
-      win32-process (~> 0.9)
-      wmi-lite (~> 1.0)
     mixlib-shellout (3.2.7-x64-mingw-ucrt)
       chef-utils
       ffi-win32-extensions (~> 1.0.3)
@@ -351,18 +350,6 @@ GEM
     rake (13.1.0)
     regexp_parser (2.9.0)
     rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
-    rest-client (2.1.0-x64-mingw32)
-      ffi (~> 1.9)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
-    rest-client (2.1.0-x86-mingw32)
-      ffi (~> 1.9)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -471,6 +458,7 @@ GEM
       strings (~> 0.2.0)
       tty-screen (~> 0.8)
     unf_ext (0.0.8.2)
+    unf_ext (0.0.8.2-x64-mingw-ucrt)
     unicode-display_width (2.5.0)
     unicode_utils (1.4.0)
     uri (0.13.0)
@@ -478,7 +466,6 @@ GEM
     vault (0.18.2)
       aws-sigv4
     webrick (1.8.1)
-    win32-api (1.10.1)
     win32-certstore (0.6.16)
       chef-powershell
       ffi
@@ -524,10 +511,7 @@ GEM
 
 PLATFORMS
   ruby
-  x64-mingw
   x64-mingw-ucrt
-  x64-mingw32
-  x86-mingw32
 
 DEPENDENCIES
   artifactory

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -17,7 +17,9 @@ end
 override "libyaml", version: "0.1.7"
 override "makedepend", version: "1.0.5"
 override "ncurses", version: "6.3"
-override "nokogiri", version: "1.13.6"
+override "nokogiri", version: aix? ? "1.13.6" : "1.18.3"
+override "libxml2", version: "2.13.5"
+override "libxslt", version: "1.1.42"
 # if you need to calculate openssl environment
 openssl_version_default =
   if macos?


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updating Libxml2 to get past this cve - https://nvd.nist.gov/vuln/detail/CVE-2024-25062 
And also upgraded libxml2 is having a dependency of libxslt so pinning it here , 
Pinning nokogiri, since the latest version upgrade of nokogiri requires ruby >=3.1.0 pinning the older version on AIX
Also removing these mingw32 platforms from gemfile as these are older


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
