### PR TITLE
remove mac 11 as its EOL and pick latest version of omnibus-software

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -51,11 +51,9 @@ builder-to-testers-map:
     - el-9-x86_64
   freebsd-13-amd64:
     - freebsd-13-amd64
-  mac_os_x-11-x86_64:
-    - mac_os_x-11-x86_64
+  mac_os_x-12-x86_64:
     - mac_os_x-12-x86_64
-  mac_os_x-11-arm64:
-    - mac_os_x-11-arm64
+  mac_os_x-12-arm64:
     - mac_os_x-12-arm64
   rocky-8-x86_64:
     - rocky-8-x86_64

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 1c244b8dfe1e1c8037353d174f54db0251cc69af
+  revision: 9de7c78bdcd58c021f3cddeea7ac573a7183fffd
   branch: main
   specs:
-    omnibus-software (24.6.323)
+    omnibus-software (24.6.324)
       omnibus (>= 9.0.0)
 
 GIT


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Removal of mac 11 as its EOL and updating mac 12 as builder . Also picked latest sha and omnibus-software version

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
