### PR TITLE
MacOS 15 support fixes

### DIFF
--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -4,7 +4,13 @@
 #
 # NOTE: You MUST update omnibus-software when adding new versions of
 # software here: bundle exec rake dependencies:update_omnibus_gemfile_lock
-override "libffi", version: "3.4.2"
+# MacOS 15 on arm64 requires newer libffi
+if macos? && platform_version.satisfies?(">=15") && !intel?
+  override "libffi", version: "3.4.7"
+else
+  override "libffi", version: "3.4.2"
+end
+
 override "libiconv", version: "1.16"
 override "liblzma", version: "5.2.5"
 override "libtool", version: "2.4.2"

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -38,4 +38,10 @@ override "ruby-windows-devkit-bash", version: "3.1.23-4-msys-1.0.18"
 override "ruby-msys2-devkit", version: ENV.fetch("MSYS_OVERRIDE", "3.1.6-1")
 override "util-macros", version: "1.19.0"
 override "xproto", version: "7.0.28"
-override "zlib", version: "1.2.11"
+
+# MacOS 15 requires newer zlib due to compilation issues
+if macos? && platform_version.satisfies?(">=15")
+  override "zlib", version: "1.3.1"
+else
+  override "zlib", version: "1.2.11"
+end


### PR DESCRIPTION
This adds support for building on MacOS 15. This requires chef/omnibus-software#1977.

- **MacOS 15 requires newer zlib due to compilation issues**
- **MacOS 15 on arm64 requires newer libffi**

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
