### PR TITLE
update nokogiri to 1.18.8 and libxslt to 1.1.43

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -24,7 +24,7 @@ pipelines:
       env:
         - ADHOC: true
         - IGNORE_CACHE: true
-        - OMNIBUS_USE_INTERNAL_SOURCES: true
+        - OMNIBUS_USE_INTERNAL_SOURCES: false
   - omnibus/adhoc-canary:
       canary: true
       definition: .expeditor/adhoc-canary.omnibus.yml

--- a/omnibus.rb
+++ b/omnibus.rb
@@ -32,7 +32,7 @@ env_omnibus_windows_arch = :x86 unless %w{x86 x64}.include?(env_omnibus_windows_
 windows_arch env_omnibus_windows_arch
 
 use_git_caching true
-use_internal_sources ENV.fetch("OMNIBUS_USE_INTERNAL_SOURCES", true)
+use_internal_sources ENV.fetch("OMNIBUS_USE_INTERNAL_SOURCES", false)
 
 # Enable S3 asset caching
 # ------------------------------

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -17,7 +17,7 @@ end
 override "libyaml", version: "0.1.7"
 override "makedepend", version: "1.0.5"
 override "ncurses", version: "6.3"
-override "nokogiri", version: aix? ? "1.13.6" : "1.18.4"
+override "nokogiri", version: aix? ? "1.13.6" : "1.18.8"
 override "libxml2", version: "2.13.5"
 override "libxslt", version: "1.1.43"
 # if you need to calculate openssl environment

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -17,9 +17,9 @@ end
 override "libyaml", version: "0.1.7"
 override "makedepend", version: "1.0.5"
 override "ncurses", version: "6.3"
-override "nokogiri", version: aix? ? "1.13.6" : "1.18.3"
+override "nokogiri", version: aix? ? "1.13.6" : "1.18.4"
 override "libxml2", version: "2.13.5"
-override "libxslt", version: "1.1.42"
+override "libxslt", version: "1.1.43"
 # if you need to calculate openssl environment
 openssl_version_default =
   if macos?


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
libxslt resolves CVE-2025-24855 and CVE-2024-55549 in version 1.1.43 which is included in nokogiri version 1.18.4. 
libxml2 resolves CVE-2025-32414 and CVE-2025-32415 in version 2.13.8 which is included in nokogiri version 1.18.8.
since omnibus_overrides is pinning all three packages (see https://github.com/chef/chef-foundation/pull/150), i'm updating the version pins for them in this PR so we don't have the older dependencies. 


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
