### PR TITLE
update nokogiri to 1.18.8 and libxml2 to 2.13.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 1945fe8117eb5db175015e7b8b34d9c6a0009b91
+  revision: 07a2cff610667896bf332b650b82062f49f0f483
   branch: main
   specs:
     omnibus-software (24.6.324)

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -17,8 +17,8 @@ end
 override "libyaml", version: "0.1.7"
 override "makedepend", version: "1.0.5"
 override "ncurses", version: "6.3"
-override "nokogiri", version: aix? ? "1.13.6" : "1.18.4"
-override "libxml2", version: "2.13.5"
+override "nokogiri", version: aix? ? "1.13.6" : "1.18.8"
+override "libxml2", version: "2.13.8"
 override "libxslt", version: "1.1.43"
 override "cgi", version: "0.3.7"
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR resolves CVEs CVE-2025-32414 and CVE-2025-32415 by updating nokogiri to 1.18.8 and libxml2 to 2.13.8

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
