### PR TITLE
revert netfetcher flags to true

### DIFF
--- a/omnibus.rb
+++ b/omnibus.rb
@@ -32,11 +32,11 @@ env_omnibus_windows_arch = :x86 unless %w{x86 x64}.include?(env_omnibus_windows_
 windows_arch env_omnibus_windows_arch
 
 use_git_caching true
-use_internal_sources ENV.fetch("OMNIBUS_USE_INTERNAL_SOURCES", false)
+use_internal_sources ENV.fetch("OMNIBUS_USE_INTERNAL_SOURCES", true)
 
 # Enable S3 asset caching
 # ------------------------------
-use_s3_caching false
+use_s3_caching true
 s3_access_key  ENV["AWS_ACCESS_KEY_ID"]
 s3_secret_key  ENV["AWS_SECRET_ACCESS_KEY"]
 s3_bucket      "opscode-omnibus-cache"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Earlier we had set this to false to avoid release build failures for a workaround , reverting them back to true to fetch omnibus-softwares from internal s3
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
