### PR TITLE
Update for bundled gem removal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: fc49fc9b9ab3755e2978d73656fe022bdcd9dcc3
+  revision: a45f01b5fdd0a11f1914d067f4c7bb39bcdddfea
   branch: main
   specs:
-    omnibus-software (25.8.334)
+    omnibus-software (25.8.338)
       omnibus (>= 9.0.0)
 
 GIT

--- a/omnibus_overrides.rb
+++ b/omnibus_overrides.rb
@@ -36,7 +36,7 @@ openssl_version_default =
 # builds for other versions in omnibus_software
 override "openssl", version: ENV.fetch("OPENSSL_OVERRIDE", openssl_version_default), fips_version: "3.1.2"
 override "pkg-config-lite", version: "0.28-1"
-override :ruby, version: aix? ? "3.0.3" : ENV.fetch("RUBY_OVERRIDE", "3.1.7"), openssl_gem: "3.3.0"
+override :ruby, version: aix? ? "3.0.3" : ENV.fetch("RUBY_OVERRIDE", "3.1.7"), openssl_gem: "3.3.0", unbundle_gems: %w[rbs typeprof]
 override "mixlib-log", version: aix? ? "3.1.1" : "3.2.0"
 override "ruby-windows-devkit-bash", version: "3.1.23-4-msys-1.0.18"
 override "ruby-msys2-devkit", version: ENV.fetch("MSYS_OVERRIDE", "3.1.7-1")


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Remove `rbs` and `typeprof` gems via the `omnibus_overrides.rb` due to their existence flagging as vulnerabilities. Neither should be in use by Chef. 

```sh
❯ bundle update --conservative omnibus-software
Fetching https://github.com/chef/omnibus-software.git
Fetching gem metadata from https://rubygems.org/........
Resolving dependencies.....
Using rake 13.1.0
Using ast 2.4.2
Using awesome_print 1.9.2
Using aws-eventstream 1.3.0
Using aws-partitions 1.937.0
Using jmespath 1.6.2
Using mixlib-log 3.0.9
Using concurrent-ruby 1.3.1
Using fuzzyurl 0.9.0
Using webrick 1.8.1
Using public_suffix 5.0.5
Using tomlrb 1.3.0
Using chef-vault 4.1.11
Using libyajl2 2.1.0
Using hashie 4.1.0
Using bcrypt_pbkdf 1.1.1
Using rack 2.2.9
Using ffi 1.16.3
Using uuidtools 2.2.0
Using artifactory 3.0.15
Using rexml 3.4.1
Using ruby-progressbar 1.13.0
Using unicode-display_width 2.5.0
Using uri 0.13.0
Using diff-lcs 1.5.1
Using tty-cursor 0.7.1
Using regexp_parser 2.9.0
Using wisper 2.0.1
Using method_source 1.1.0
Using multipart-post 2.4.1
Using parslet 2.0.0
Using parallel 1.24.0
Using racc 1.7.3
Using rspec-support 3.12.2
Using semverse 3.0.2
Using tty-color 0.6.0
Using strings-ansi 0.2.0
Using erubis 2.7.0
Using unicode_utils 1.4.0
Using net-ssh 7.2.3
Using mixlib-cli 2.1.8
Using iniparse 1.5.0
Using date 3.3.4
Using mixlib-authentication 3.0.10
Using plist 3.7.1
Using thor 1.2.2
Using wmi-lite 1.0.7
Using coderay 1.1.3
Using http-accept 1.7.0
Using rubyzip 2.3.2
Using domain_name 0.6.20240107
Using netrc 0.11.0
Using tty-screen 0.8.2
Using builder 3.2.4
Using ipaddress 0.8.3
Using erubi 1.12.0
Using little-plugger 1.1.4
Using sslshake 1.3.1
Using rubyntlm 0.6.3
Using mime-types-data 3.2024.0507
Using rainbow 3.1.1
Using multi_json 1.15.0
Using minitar 0.9
Using retryable 3.0.5
Using molinillo 0.8.0
Using bundler 2.3.7
Using timeout 0.4.1
Using proxifier2 1.1.0
Using contracts 0.16.1
Using bigdecimal 3.1.8
Using unf_ext 0.0.8.2
Using mixlib-versioning 1.2.12
Using openssl 3.3.0
Using json 2.7.2
Using aws-sigv4 1.8.0
Using syslog-logger 1.6.8
Using mixlib-archive 1.1.7
Using chef-utils 18.4.12
Using addressable 2.8.6
Using mixlib-config 3.0.27
Using ffi-yajl 2.6.0
Using corefoundation 0.3.13
Using ffi-libarchive 1.1.14
Using gssapi 1.3.1
Using net-http 0.4.1
Using parser 3.3.0.5
Using rspec-core 3.12.3
Using rspec-expectations 3.12.4
Using httpclient 2.8.3
Using pastel 0.8.0
Using time 0.3.0
Using net-scp 4.0.0
Using chef-cleanroom 1.0.5
Using pry 0.14.2
Using cleanroom 1.0.0
Using iostruct 0.1.2
Using http-cookie 1.0.5
Using zhexdump 0.1.1
Using logging 2.3.1
Using rspec-mocks 3.12.7
Using net-protocol 0.2.2
Using gyoku 1.4.0
Using aws-sdk-core 3.196.1
Using nori 2.7.0
Using chef-zero 15.0.11
Using tty-reader 0.9.0
Using mixlib-shellout 3.2.7
Using net-sftp 4.0.0
Using faraday-net_http 3.1.0
Using pedump 0.6.10
Using rspec 3.12.0
Using ed25519 1.3.0
Using rubocop-ast 1.31.2
Using rspec-its 1.3.0
Using vault 0.18.2
Using net-ssh-gateway 2.0.0
Using citrus 3.0.2
Using train-core 3.12.3
Using winrm 2.3.6
Using mixlib-install 3.12.30
Using solve 4.0.4
Using strings 0.2.1
Using aws-sdk-secretsmanager 1.95.0
Using toml-rb 2.2.0
Using tty-table 0.12.0
Using rubocop 1.25.1
Using aws-sdk-kms 1.82.0
Using cookstyle 7.32.8
Using mime-types 3.5.2
Using aws-sdk-s3 1.116.0
Using rest-client 2.1.0
Using chef-config 18.4.12
Using tty-box 0.7.0
Using train-rest 0.5.0
Using net-ftp 0.3.4
Using license_scout 1.3.18
Using chef-telemetry 1.1.1
Using winrm-fs 1.3.5
Using ohai 18.1.3
Using winrm-elevated 1.2.3
Using faraday 2.9.0
Using tty-prompt 0.23.1
Using faraday-follow_redirects 0.3.0
Using license-acceptance 2.1.13
Using sawyer 0.9.2
Using inspec-core 5.22.50
Using omnibus 9.1.0 from https://github.com/chef/omnibus.git (at main@d3264e1)
Using test-kitchen 3.5.1
Using train-winrm 0.2.13
Using octokit 4.25.1
Using kitchen-vagrant 1.14.2
Using chef 18.4.12
Using berkshelf 8.0.9
Using omnibus-software 25.8.338 (was 25.8.334) from https://github.com/chef/omnibus-software.git (at main@a45f01b)
Bundle updated!
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
